### PR TITLE
Added standalone template certificate.ymlj2

### DIFF
--- a/templates/certificate.yml.j2
+++ b/templates/certificate.yml.j2
@@ -1,0 +1,21 @@
+#jinja2: lstrip_blocks: True
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: SSL Certifictes
+
+Resources:
+{% for resource, config in (Config.Certificates|default({})).items() %}
+  {{ resource }}Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: "{{ config.DomainName }}"
+      SubjectAlternativeNames:
+        {{ config.SubjectAlternativeNames | default([]) | to_nice_yaml(indent=2) | indent(8, False) }}
+      DomainValidationOptions:
+        - DomainName: "{{ config.DomainName }}"
+          ValidationDomain: "{{ config.DomainName|regex_replace('^(.+?)?(?P<root>[a-z\-]+?\.[a-z]+)$', '\\g<root>') }}"
+        {% for option in config.ValidationOptions|default([]) %}
+        - DomainName: "{{ option.DomainName }}"
+          ValidationDomain: "{{ option.ValidationDomain }}"
+        {% endfor %}
+{% endfor %}


### PR DESCRIPTION
Adds a generic/standalone certificate template. To use, open ./group_vars/env/vars.yml and modify as so:

```yaml
Config.Certificates:
  DevCasebookPlatformOrg:
    DomainName: *.dev.casebookplatform.org
    SubjectAlternativeNames:
      - www.casebook.com
    ValidationOptions:
      - DomainName: *.casebookplatform.org
        ValidationDomain: casebookplatform.org
```

