### PR TITLE
Support multiple dependency mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,14 @@ The following is an example of a playbook configured to use this role.  Note the
 
 ## Release Notes
 
+### Version 0.9.1
+
+- **ENHANCEMENT** : Support list of default dependency mappings in stack transform feature
+- **BUG FIX** : Fix issue where DependsOn property renaming for stack transform resource fails if component resource does not having existing DependsOn property
+
 ### Version 0.9.0
 
+- **NEW FEATURE** : Added stack transforms, a new feature to support merging component templates into a master template
 - **NEW FEATURE** : Added stack overrides, a new syntax to override portions of the stack template
 - **BREAKING CHANGE** : Auto generated stack inputs now rely on the `Stack.Inputs` dictionary, and support the same dot notation naming scheme of stack overrides
 - **ENHANCEMENT**: Add S3 bucket name exports to [CloudFormation template](`templates/cfn.yml.j2`)


### PR DESCRIPTION
This PR supports multiple dependency mappings in component templates:

```
AWSTemplateFormatVersion: "2010-09-09"

Description: Sumologic Resources

Metadata:
  Stack::Transform:
    DefaultDependencyMappings:
      - CollectorPermission
      - CollectorLambdaPermission
```

With these changes, any resources configured in the main template that depend on the transform resource will depend all of the listed default dependency mapping resources.

For example given the following master template snippet:

```
# Transform Resource
Sumologic:
    Type: Stack::Transform
    Template: sumologic.yml.j2
    Properties:
      Name: Sumologic
      SecretsProvisioner:
        Fn::Sub: ${SecretsProvisioner.Arn}
      SecretsProvisionerKey:
        Fn::ImportValue: CfnMasterKey
      ProvisionerVersion:
        Ref: SumologicProvisionerVersion
      CollectorVersion:
        Ref: SumologicCollectorVersion

# Depending Resources
ReaderNotificationsLogGroupSubscription:
    Type: AWS::Logs::SubscriptionFilter
    DependsOn:
      - Sumologic
    Properties:
      DestinationArn:
        Fn::Sub: ${Sumologic.CollectorFunction.Arn}
      FilterPattern: ""
      LogGroupName:
        Ref: ReaderNotificationsLogGroup
```

The following output template would be generated:

```
ReaderNotificationsLogGroupSubscription:
    DependsOn:
    - SumologicCollectorPermission
    - SumologicCollectorLambdaPermission
    Properties:
      DestinationArn:
        Fn::Sub: ${SumologicCollectorFunction.Arn}
      FilterPattern: ''
      LogGroupName:
        Ref: ReaderNotificationsLogGroup
    Type: AWS::Logs::SubscriptionFilter
```

This PR also fixes a bug where a transform resource depends on another master stack resource and the default dependency mapping resources in the component template do not currently depend on other component resources.
