### PR TITLE
Include stack tags with generated config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,6 @@ The following is an example of a playbook configured to use this role.  Note the
 - - **NEW FEATURE** : Added generic [dns template](`https://github.com/Casecommons/aws-cloudformation/pull/7`)
 - - **NEW FEATURE** : Added generic CA [certificate template](`https://github.com/Casecommons/aws-cloudformation/pull/9`)
 
-### Version 0.9.3
-
-- **ENHANCEMENT** : Include stack tags with generated `config.json` files
-
 ### Version 0.9.2
 
 - **BUG FIX** : Output `config.json` with all values as strings (required for CodePipeline CloudFormation deployment support)

--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ The following is an example of a playbook configured to use this role.  Note the
 
 ## Release Notes
 
+### Version 0.9.5
+
+- **ENHANCEMENT** : Include stack tags with generated `config.json` files
+
 ### Version 0.9.4
 
 - **BUG FIX** : Removed jinja references to Stack.Name in template s3.yml.j2 since it is redundant and susceptible to breakage `./templates/s3.yml/j2`
@@ -280,6 +284,9 @@ The following is an example of a playbook configured to use this role.  Note the
 - - **NEW FEATURE** : Added generic [dns template](`https://github.com/Casecommons/aws-cloudformation/pull/7`)
 - - **NEW FEATURE** : Added generic CA [certificate template](`https://github.com/Casecommons/aws-cloudformation/pull/9`)
 
+### Version 0.9.3
+
+- **ENHANCEMENT** : Include stack tags with generated `config.json` files
 
 ### Version 0.9.2
 

--- a/README.md
+++ b/README.md
@@ -279,10 +279,10 @@ The following is an example of a playbook configured to use this role.  Note the
 ### Version 0.9.3
 
 - **NEW FEATURE** : Added generic [cloudfront template](`https://github.com/Casecommons/aws-cloudformation/pull/2`)
-- - **NEW FEATURE** : Added generic [s3 template](`https://github.com/Casecommons/aws-cloudformation/pull/4`)
-- - **ENHANCEMENT** : Updated jinja indentation on [ecr template](`https://github.com/Casecommons/aws-cloudformation/pull/4`)
-- - **NEW FEATURE** : Added generic [dns template](`https://github.com/Casecommons/aws-cloudformation/pull/7`)
-- - **NEW FEATURE** : Added generic CA [certificate template](`https://github.com/Casecommons/aws-cloudformation/pull/9`)
+- **NEW FEATURE** : Added generic [s3 template](`https://github.com/Casecommons/aws-cloudformation/pull/4`)
+- **ENHANCEMENT** : Updated jinja indentation on [ecr template](`https://github.com/Casecommons/aws-cloudformation/pull/4`)
+- **NEW FEATURE** : Added generic [dns template](`https://github.com/Casecommons/aws-cloudformation/pull/7`)
+- **NEW FEATURE** : Added generic CA [certificate template](`https://github.com/Casecommons/aws-cloudformation/pull/9`)
 
 ### Version 0.9.2
 

--- a/tasks/generator.yml
+++ b/tasks/generator.yml
@@ -55,6 +55,7 @@
         cf_stack_config:
           Parameters: "{{ cf_stack_inputs }}"
           StackPolicy: "{{ cf_stack_policy }}"
+          Tags: "{{ cf_stack_tags }}"
     - name: generate stack config
       copy: content={{ cf_stack_config | to_json }} dest={{ cf_stack_config_json }}
       changed_when: False


### PR DESCRIPTION
This PR adds any defined stack tags (as configured via `Stack.Tags`) to generated environment config files.  This ensures Stack tags will be applied if using CodePipeline CloudFormation deployment actions.