### PR TITLE
Set Region To Fake Global

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ The following is an example of a playbook configured to use this role.  Note the
 
 ## Release Notes
 
+### Version 0.9.6
+
+- **BUG FIX** : Set s3 module region to "global" in `./tasks/s3.yml`
+
 ### Version 0.9.5
 
 - **ENHANCEMENT** : Include stack tags with generated `config.json` files

--- a/tasks/s3.yml
+++ b/tasks/s3.yml
@@ -23,6 +23,7 @@
       bucket: "{{ cf_s3_bucket }}"
       object: "{{ cf_stack_name }}/{{ current_timestamp }}/stack.json"
       src: "{{ cf_stack_template_json }}"
+      region: global
     changed_when: false
     register: cf_s3_result
   - name: set S3 url fact


### PR DESCRIPTION
When executing the ansible s3 module, it seems that bucket will be
"registered" to fake region, even though AWS considers buckets to be of
region type global. If we execute an operation against a bucket
registered as us-east-1, but with AWS_REGION set to us-east-2, we get
the error detailed in the below issue. Setting region attribute of s3
module to "global" mitigates this issue.

https://github.com/ansible/ansible/issues/29397

```bash
TASK [aws-cloudformation : upload template to S3] *************************************************************************************************************************
task path: /Users/ccuser/workspace/network-resources/roles/aws-cloudformation/tasks/s3.yml:20
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: <Error><Code>BucketAlreadyOwnedByYou</Code><Message>Your previous request to create the named bucket succeeded and you already own it.</Message><BucketName>334274607422-cfn-templates</BucketName><RequestId>FBDCFC5073C27A9F</RequestId><HostId>CsElyptX4BhnPajcnewd4AZtkJAKKcnlvLVNBc2yOA135x9RD/Io9w+1irxk/6LYJQIm7IMT66A=</HostId></Error>
fatal: [cbp-acceptance]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/5t/zktcbz5s6xb1cfgk7pvq2vyc0000gk/T/ansible_7xOJsp/ansible_module_s3.py\", line 765, in <module>\n    main()\n  File \"/var/folders/5t/zktcbz5s6xb1cfgk7pvq2vyc0000gk/T/ansible_7xOJsp/ansible_module_s3.py\", line 629, in main\n    create_bucket(module, s3, bucket, location)\n  File \"/var/folders/5t/zktcbz5s6xb1cfgk7pvq2vyc0000gk/T/ansible_7xOJsp/ansible_module_s3.py\", line 314, in create_bucket\n    bucket = s3.create_bucket(bucket, location=location)\n  File \"/Users/ccuser/Library/Python/2.7/lib/python/site-packages/boto/s3/connection.py\", line 623, in create_bucket\n    response.status, response.reason, body)\nboto.exception.S3CreateError: S3CreateError: 409 Conflict\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>BucketAlreadyOwnedByYou</Code><Message>Your previous request to create the named bucket succeeded and you already own it.</Message><BucketName>334274607422-cfn-templates</BucketName><RequestId>FBDCFC5073C27A9F</RequestId><HostId>CsElyptX4BhnPajcnewd4AZtkJAKKcnlvLVNBc2yOA135x9RD/Io9w+1irxk/6LYJQIm7IMT66A=</HostId></Error>\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
```