### PR TITLE
Support Ansible 2.4 and Python 3 (backwards compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an Ansible role for generating CloudFormation templates and deploying Cl
 
 ## Requirements
 
-- Python 2.7
+- Python 2.7 or 3.4+
 - PIP package manager (**easy_install pip**)
 - Ansible 2.2 or greater (**pip install ansible**)
 - Boto (**pip install boto**)

--- a/filter_plugins/dict_override.py
+++ b/filter_plugins/dict_override.py
@@ -6,4 +6,4 @@ class FilterModule(object):
     }
 
 def dict_override(source, overrides, selector='Type'):
-  return {pk:v for k,v in overrides.iteritems() for pk, pv in source.iteritems() if pv.get(selector) == k}
+  return {pk:v for k,v in overrides.items() for pk, pv in source.items() if pv.get(selector) == k}

--- a/filter_plugins/dotted_dict.py
+++ b/filter_plugins/dotted_dict.py
@@ -1,6 +1,7 @@
 import operator
 import json
 from collections import defaultdict
+from functools import reduce
 
 class FilterModule(object):
   ''' Converts CloudFormation Template Parameters to Stack Input mappings '''
@@ -12,7 +13,7 @@ class FilterModule(object):
 def dotted_dict(vars, paths=[]):
   infinitedict = lambda: defaultdict(infinitedict)
   data = infinitedict()
-  vars_keys = vars.keys()
+  vars_keys = list(vars.keys())
   vars_keys.sort(key=len)
   params = [(k,vars[k]) for p in paths for k in vars_keys if k.startswith(p) ]
   for param in params:

--- a/filter_plugins/stack_inputs.py
+++ b/filter_plugins/stack_inputs.py
@@ -9,7 +9,7 @@ class FilterModule(object):
 
 def stack_inputs(inputs, config):
   result = {}
-  for key,value in inputs.items():
+  for key,value in list(inputs.items()):
     try:
       result[key] = str(config.get(key) or value['Default'])
     except KeyError as e:

--- a/filter_plugins/stack_transforms.py
+++ b/filter_plugins/stack_transforms.py
@@ -1,11 +1,17 @@
 from jinja2 import Template,FileSystemLoader,Environment,TemplateNotFound
-from ansible.plugins import filter_loader
 from ansible.errors import AnsibleError
 import yaml
 import os
 import re
 import logging
 from functools import reduce
+
+try:
+    # Ansible >= 2.4
+    from ansible.plugins.loader import filter_loader
+except ImportError:
+    # Ansible < 2.4
+    from ansible.plugins import filter_loader
 
 FORMAT = "[stack_transform]: %(message)s"
 PROPERTY_TRANSFORM = 'Property::Transform'


### PR DESCRIPTION
Add support for Ansible 2.4 and Python 3.x in a backwards compatible way. 
Still works with Ansible < 2.4 and Python 2.7.