### PR TITLE
Only disable stack policy when active stack exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ The following is an example of a playbook configured to use this role.  Note the
 
 ## Release Notes
 
+### Version 2.4.1
+
+- **BUG FIX**: Disable stack policy only if an active stack currently exists
+
 ### Version 2.4.0
 
 - **BREAKING CHANGE** : Compatibility fixes for Ansible 2.4.x

--- a/tasks/disable_policy.yml
+++ b/tasks/disable_policy.yml
@@ -1,6 +1,10 @@
 ---
 - block:
+  - name: check stack currently exists
+    shell: aws cloudformation list-stacks --query "StackSummaries[?StackName=='{{ cf_stack_name }}' && StackStatus != 'DELETE_COMPLETE' && StackStatus != 'DELETE_IN_PROGRESS']" --output text
+    changed_when: False
+    register: cf_stack_exists
   - name: disable current stack policy
     shell: aws cloudformation set-stack-policy --stack-name '{{ cf_stack_name }}' --stack-policy-body '{{ cf_default_stack_policy | to_json }}'
     changed_when: False
-
+    when: cf_stack_exists.stdout


### PR DESCRIPTION
This PR fixes an issue where attempting to disable stack policy (by setting `Stack.DisablePolicy` to true) fails if an active stack does not currently exist.