### PR TITLE
Add environment to template file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ The following is an example of a playbook configured to use this role.  Note the
 
 ## Release Notes
 
+### Version 2.5.1
+
+- **BUG FIX**: Ensure template and config files are unique when stack name is same across multiple environments
+
 ### Version 2.5.0
 
 - **ENHANCEMENT**: Compatible with Ansible 2.5

--- a/tasks/generator.yml
+++ b/tasks/generator.yml
@@ -2,11 +2,11 @@
 - block:
     - name: set template encoding facts
       set_fact:
-        cf_stack_template_yaml: "{{ cf_build_folder }}/{{ cf_stack_name }}-stack.yml"
-        cf_stack_template_json: "{{ cf_build_folder }}/{{ cf_stack_name }}-stack.json"
-        cf_stack_template_temp_json: "{{ cf_build_folder }}/{{ cf_stack_name }}-stack.tmp.json"
-        cf_stack_policy_json: "{{ cf_build_folder }}/{{ cf_stack_name }}-policy.json"
-        cf_stack_config_json: "{{ cf_build_folder }}/{{ cf_stack_name }}-config.json"
+        cf_stack_template_yaml: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-stack.yml"
+        cf_stack_template_json: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-stack.json"
+        cf_stack_template_temp_json: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-stack.tmp.json"
+        cf_stack_policy_json: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-policy.json"
+        cf_stack_config_json: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-config.json"
     - name: generate YAML template
       template:
         src: "{{ cf_stack_template }}"


### PR DESCRIPTION
This ensures generate template and config files are always unique.  Currently if you use the same stack name across multiple environments, generating configs for multiple environments will overwrite each other.