### PR TITLE
Add jmespath override support

### DIFF
--- a/filter_plugins/cfn_dotted_dict.py
+++ b/filter_plugins/cfn_dotted_dict.py
@@ -1,21 +1,25 @@
 import operator
 import json
+import re
 from collections import defaultdict
 
 class FilterModule(object):
   ''' Converts CloudFormation Template Parameters to Stack Input mappings '''
   def filters(self):
     return {
-        'dotted_dict': dotted_dict
+      'cfn_dotted_dict': cfn_dotted_dict
     }
 
-def dotted_dict(vars, paths=[]):
+def cfn_dotted_dict(vars, paths=[]):
   infinitedict = lambda: defaultdict(infinitedict)
   data = infinitedict()
   vars_keys = vars.keys()
   vars_keys.sort(key=len)
   params = [(k,vars[k]) for p in paths for k in vars_keys if k.startswith(p) ]
   for param in params:
+    # Only process params with dotted syntax,others are processed by stack_overrides
+    if re.search('[\[\]\*]+',param[0]):
+      continue
     keys = param[0].split('.')
     parent = reduce(operator.getitem, keys[:-1], data)
     parent[keys[-1]] = param[1]

--- a/filter_plugins/stack_overrides.py
+++ b/filter_plugins/stack_overrides.py
@@ -1,0 +1,95 @@
+import re
+import jmespath
+
+class FilterModule(object):
+  ''' Converts CloudFormation Template Parameters to Stack Input mappings '''
+  def filters(self):
+    return {
+      'stack_overrides': stack_overrides
+    }
+
+# Flattens list of lists until the inner most list is reached
+# Then mutates element inner most list at index with data
+def flatten(op, parent, data, index=0):
+  for p in parent:
+    if type(p) is list:
+      flatten(op, p, data, index)
+    else:
+      op(parent, data, index)
+      break
+
+# Assign operator for flatten
+def assign(parent, data, index):
+  parent[index] = data
+
+# Append operator for flatten
+def append(parent, data, index):
+  parent += data
+
+def stack_overrides(vars, source='Stack', paths=[
+  'Description','Metadata','Parameters', 'Resources', 'Mappings', 'Outputs', 'Conditions'
+]):
+  # Selects top level source object - e.g. 'Stack'
+  data = vars[source]
+  # Sort keys based upon selector depth
+  vars_keys = vars.keys()
+  vars_keys.sort(key=lambda k: len(k.split(".")))  # TODO: what if filters have '.' characters?
+  # Assuming [{'Stack.x.x.x': 'value'}...]
+  # Returns tuples in form [('Stack.x.x.x', 'value')...]
+  params = [(k,vars[k]) for p in paths for k in vars_keys if k.startswith(source + '.' + p)]
+  for param in params:
+    # Ignore params with only dotted syntax, they are processed by dotted dict
+    if not re.search('[\[\]\*]+',param[0]):
+      continue
+    parts = param[0].split(".",1)
+    if len(parts) == 1:
+      data = param[1]
+      continue
+    parts = parts[1].rsplit(".",1)
+    if len(parts) == 1:
+      data[parts[0]] = param[1]
+      continue
+    path = parts[0]
+    key = parts[1]
+    key_parts = re.match('(.*)\[(.*)\]$',key)
+    if key_parts:
+      key_prop = key_parts.groups()[0]
+      key_filter = key_parts.groups()[1]
+      if key_filter and key_filter.isdigit():
+        # Example: Stack.Resources.MyResource.Values[0]: <new value>
+        # Here we need to select path + key_prop and then use key_filter as index
+        parent = jmespath.search(path + '.' + key_prop, data)
+        if parent is None:
+          continue
+        if type(parent) is list:
+          flatten(assign, parent, param[1], int(key_filter))
+        else:
+          parent[int(key_filter)] = param[1]
+      elif not key_filter:
+        # Example: Stack.Resources.MyResource.Values[]: <new value>
+        # Here we need to add value to path + key_prop
+        parent = jmespath.search(path + '.' + key_prop, data)
+        if parent is None:
+          continue
+        flatten(append, parent, param[1])
+      else:
+        # Example: Stack.Resources.MyResource.Values[?prop='value']: <new value>
+        # Here we assume <new value> is a dict and we need to replace dict keys/values with <new value? keys/values
+        parent = jmespath.search(path + '.' + key, data)
+        if parent is None:
+          continue
+        for p in parent:
+          for k in list(p):
+            del p[k]
+          for k,v in param[1].items():
+            p[k] = v
+    else:
+      parent = jmespath.search(path, data)
+      if parent is None:
+        continue
+      if type(parent) is list:
+        for p in parent:
+          p[key] = param[1]
+      else:
+        parent[key] = param[1]  
+  return data

--- a/tasks/generator.yml
+++ b/tasks/generator.yml
@@ -26,9 +26,12 @@
       set_fact:
         Stack: "{{ Stack | combine({ 'Resources': Stack.Resources | dict_override(cf_stack_globals)}, recursive=True) }}"
         cf_stack_template_vars: "{{ cf_stack_template_vars | combine({ 'Resources':cf_stack_template_vars.Resources | dict_override(cf_stack_globals)}, recursive=True) }}"
-    - name: apply stack overrides
+    - name: apply simple stack overrides
       set_fact:
         cf_stack_template_vars: "{{ cf_stack_template_vars | combine(cf_stack_overrides, recursive=True) }}"
+    - name: apply complex overrides
+      set_fact:
+        Stack: "{{ Stack | combine(vars['hostvars'][env] | stack_overrides, recursive=True) }}"
     - name: apply stack property transforms
       set_fact:
         Stack: "{{ Stack | property_transform(filter_paths=[role_path + '/filter_plugins']) }}"

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -2,8 +2,8 @@
 - block:
   - name: create stack variables
     set_fact:
-      Stack: "{{ Stack | default({}) | combine((vars['hostvars'][env] | dotted_dict(paths=['Stack.'])).get('Stack') or {}, recursive=True) }}"
-      Config: "{{ Stack | default({}) | combine((vars['hostvars'][env] | dotted_dict(paths=['Config.'])).get('Config') or {}, recursive=True) }}"
+      Stack: "{{ Stack | default({}) | combine((vars['hostvars'][env] | cfn_dotted_dict(paths=['Stack.'])).get('Stack') or {}, recursive=True) }}"
+      Config: "{{ Stack | default({}) | combine((vars['hostvars'][env] | cfn_dotted_dict(paths=['Config.'])).get('Config') or {}, recursive=True) }}"
 
   - name: create stack facts
     set_fact:
@@ -18,7 +18,7 @@
         'Outputs': Stack.Outputs | default({}),
         'Conditions': Stack.Conditions | default({})
       } }}"
-      cf_stack_globals: "{{ vars['hostvars'][env] | dotted_dict(paths=['AWS::']) }}"
+      cf_stack_globals: "{{ vars['hostvars'][env] | cfn_dotted_dict(paths=['AWS::']) }}"
       cf_job_path: "{{ Stack.Path | default('./build') }}"
       cf_delete_stack: "{{ Stack.Delete | default(False) | bool }}"
       cf_disable_stack_policy: "{{ Stack.DisablePolicy | default(False) | bool }}"


### PR DESCRIPTION
This PR adds support for JMESPath queries when defining stack overrides.

E.g.

```
# Set the resource types of all resources to AWS::Foo
Stack.Resources.*.Type: AWS::Foo

# Set the first statement effect to Deny
Stack.Resources.MasterKey.Properties.KeyPolicy.Statement[0].Effect: Deny

# Override environment for container definitions with a name of squid
Stack.Resources.MyResource.Properties.ContainerDefinitions[?Name=='squid'].Environment:
  - Name: FOO
    Value: bar

# Append to (rather than override) environment for container definitions with a name of squid
# The append operation applies whenever you include [] at the end of the override
Stack.Resources.MyResource.Properties.ContainerDefinitions[0].Environment[]:
  - Name: FOO
    Value: bar
```