### PR TITLE
Use AWS CLI for deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,10 @@ The following is an example of a playbook configured to use this role.  Note the
 
 ## Release Notes
 
+### Version 2.7.1
+
+- **ENHANCEMENT**: Use AWS CLI for deployments.  This enables support for SAM templates and other template features that require a change set to be created as part of the deployment process.
+
 ### Version 2.7.0
 
 - **ENHANCEMENT**: Ansible 2.7 and Python 3 support

--- a/filter_plugins/dict_override.py
+++ b/filter_plugins/dict_override.py
@@ -1,9 +1,14 @@
-class FilterModule(object):
-  ''' Returns dictionary of items with keyed overrides that override properties with a matching selector'''
-  def filters(self):
-    return {
-        'dict_override': dict_override
-    }
-
-def dict_override(source, overrides, selector='Type'):
-  return {pk:v for k,v in overrides.items() for pk, pv in source.items() if pv.get(selector) == k}
+class FilterModule(object): 
+  ''' Returns dictionary of items with keyed overrides that override properties with a matching selector''' 
+  def filters(self): 
+    return { 
+        'dict_override': dict_override, 
+        'dict_to_kv_string': dict_to_kv_string 
+    } 
+ 
+def dict_override(source, overrides, selector='Type'): 
+  return {pk:v for k,v in overrides.items() for pk, pv in source.items() if pv.get(selector) == k} 
+ 
+# Returns dict as 'key1=value1<separator>key2=value2 ...' 
+def dict_to_kv_string(source, separator=' '): 
+  return ' '.join([ "{}={}".format(k,v) for k,v in source.items() ])

--- a/tasks/cloudformation.yml
+++ b/tasks/cloudformation.yml
@@ -1,35 +1,31 @@
----
-- block:
-    - name: set local path fact if s3 upload disabled
-      set_fact:
-        cf_stack_template_path: "{{ cf_stack_template_json }}"
-      when: not cf_upload_s3 | default(false) | bool
-    - name: configure application stack
-      cloudformation:
-        stack_name: "{{ cf_stack_name }}"
-        stack_policy: "{{ cf_stack_policy_json }}"
-        state: present
-        template: "{{ cf_stack_template_path | default(omit) }}"
-        template_url: "{{ cf_s3_template_url | default(omit) }}"
-        template_parameters: "{{ cf_stack_inputs }}"
-        disable_rollback: "{{ cf_disable_rollback }}"
-        role_arn: "{{ cf_stack_role | default(omit) }}"
-        tags: "{{ cf_stack_tags }}"
-      register: cf_stack_result
-  tags:
-    - deploy
-
-- block:
-    - name: get stack facts
-      cloudformation_facts:
-        stack_name: "{{ cf_stack_name }}"
-        stack_resources: true
-      changed_when: false
-    - name: set stack facts
-      set_fact:
-        Stack: "{{ Stack | combine({ 'Facts': cloudformation[cf_stack_name] },recursive=True) }}"
-    - name: Stack.Facts variable
-      debug: msg={{ Stack.Facts }}
-      when: debug
-  tags:
+--- 
+- block: 
+    - name: generate parameter overrides 
+      set_fact: 
+        cf_parameter_overrides: "{{ cf_stack_inputs | dict_to_kv_string }}" 
+    - name: deploy stack 
+      shell: aws cloudformation deploy 
+        --stack-name {{ cf_stack_name }} 
+        --template-file {{ cf_stack_template_yaml }} 
+        {{ '--s3-bucket ' + cf_s3_bucket if cf_upload_s3 else '' }} 
+        {{ '--s3-prefix ' + cf_stack_name + '/' + current_timestamp if cf_upload_s3 else ''}} 
+        {{ '--parameter-overrides ' + cf_parameter_overrides if cf_parameter_overrides else '' }} 
+        {{ '--role-arn=' + cf_stack_role if cf_stack_role else '' }} 
+        --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND 
+        --no-fail-on-empty-changeset 
+  tags: 
+    - deploy 
+ 
+- block: 
+    - name: get stack facts 
+      cloudformation_facts: 
+        stack_name: "{{ cf_stack_name }}" 
+        stack_resources: true 
+      changed_when: false 
+    - name: set stack facts 
+      set_fact: 
+        Stack: "{{ Stack | combine({'Facts': cloudformation[cf_stack_name]},recursive=True) }}" 
+    - debug: msg={{ Stack.Facts }} 
+      when: debug 
+  tags: 
     - deploy

--- a/tasks/generator.yml
+++ b/tasks/generator.yml
@@ -3,8 +3,6 @@
     - name: set template encoding facts
       set_fact:
         cf_stack_template_yaml: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-stack.yml"
-        cf_stack_template_json: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-stack.json"
-        cf_stack_template_temp_json: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-stack.tmp.json"
         cf_stack_policy_json: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-policy.json"
         cf_stack_config_json: "{{ cf_build_folder }}/{{ env }}-{{ cf_stack_name }}-config.json"
     - name: generate YAML template
@@ -41,9 +39,6 @@
     - name: generate stack policy
       copy: content={{ cf_stack_policy | to_json }} dest={{ cf_stack_policy_json }}
       changed_when: False
-    - name: generate compact JSON template
-      copy: content={{ lookup('file', cf_stack_template_yaml) | from_yaml | compact | string }} dest={{ cf_stack_template_json }}
-      changed_when: False
     - name: set stack inputs
       set_fact:
         cf_stack_inputs: "{{ cf_stack_inputs | default(Stack.Parameters | default({}) | stack_inputs(Stack.Inputs | default({}))) }}"
@@ -56,5 +51,13 @@
     - name: generate stack config
       copy: content={{ cf_stack_config | to_json }} dest={{ cf_stack_config_json }}
       changed_when: False
+    - name: detect template size
+      stat:
+        path: "{{ cf_stack_template_yaml }}"
+      register: cf_stack_template_stat
+    - name: set upload flag if template exceeds 51,200 bytes
+      set_fact:
+        cf_upload_s3: True
+      when: cf_stack_template_stat.stat.size > 51200
   tags:
     - generate

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,16 +4,21 @@
 
 - block:
     - import_tasks: disable_policy.yml
-  when: cf_disable_stack_policy
+  when: cf_disable_stack_policy | default(False) | bool
 
 - block:
     - import_tasks: generator.yml
     - import_tasks: s3.yml
-      when: cf_upload_s3
     - import_tasks: cloudformation.yml
+  rescue:
+    - name: capture failure
+      set_fact: 
+        cf_failure: "True"
   always:
     - import_tasks: enable_policy.yml
       when: cf_disable_stack_policy
+    - fail: msg="A playbook error occurred"
+      when: cf_failure | default(False) | bool
   when: not cf_delete_stack
 
 - block:

--- a/tasks/s3.yml
+++ b/tasks/s3.yml
@@ -1,35 +1,17 @@
----
-- block:
-  - name: obtain account id
-    shell: aws sts get-caller-identity
-    changed_when: false
-    register: cf_aws_identity
-  - debug: msg={{ cf_aws_identity }}
-    when: debug
-  - name: set aws account fact
-    set_fact:
-      cf_account_id: "{{ (cf_aws_identity.stdout | from_json).get('Account') }}"
-  - name: set s3 bucket fact for account id {{ cf_account_id }}
-    set_fact:
-      cf_s3_bucket: "{{ cf_account_id + '-cfn-templates' }}"
-  when: cf_s3_bucket is not defined
-  tags:
-    - generate
-
-- block:
-  - name: upload template to S3
-    aws_s3:
-      mode: put
-      bucket: "{{ cf_s3_bucket }}"
-      object: "{{ cf_stack_name }}/{{ current_timestamp }}/stack.json"
-      src: "{{ cf_stack_template_json }}"
-    changed_when: false
-    register: cf_s3_result
-  - name: set S3 url fact
-    set_fact:
-      cf_s3_template_url: "{{ cf_s3_result.url.split('?') | first }}"
-      Stack: "{{ Stack | combine({'Url':cf_s3_result.url},recursive=True) }}"
-  - name: S3 url
-    debug: msg={{ Stack.Url }}
-  tags:
-    - generate
+--- 
+- block: 
+  - name: obtain account id 
+    shell: aws sts get-caller-identity 
+    changed_when: false 
+    register: cf_aws_identity 
+  - debug: msg={{ cf_aws_identity }} 
+    when: debug 
+  - name: set aws account fact 
+    set_fact: 
+      cf_account_id: "{{ (cf_aws_identity.stdout | from_json).get('Account') }}" 
+  - name: set s3 bucket fact for account id {{ cf_account_id }} 
+    set_fact: 
+      cf_s3_bucket: "{{ cf_account_id + '-cfn-templates' }}" 
+  when: cf_s3_bucket is not defined 
+  tags: 
+    - generate 


### PR DESCRIPTION
This PR changes the deployment mechanism to the AWS CLI, which adds support for templates that require change sets to be created as part of the deployment process (e.g. SAM templates).